### PR TITLE
skip the header animation when video play event does not occur

### DIFF
--- a/_sass/layout/_masthead.scss
+++ b/_sass/layout/_masthead.scss
@@ -49,6 +49,7 @@ header.masthead {
 }
 
 // show masthead text if video cannot be started by js
+header.masthead.skip-video video + .container,
 .no-js header.masthead video + .container {
   opacity: 1;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,13 +10,19 @@ if ('scrollRestoration' in history) {
         return;
     }
     if (matchMedia('(prefers-reduced-motion)').matches) {
+        video.parentNode.classList.add('skip-video');
         return;
     }
     if (matchMedia(video.getAttribute('data-small-media')).matches) {
         video.src = video.getAttribute('data-small-src');
     }
     video.autoplay = true;
+    // skip the video if play event doesnt happen in 3 seconds
+    var playTimeout = setTimeout(function(){
+        video.parentNode.classList.add('skip-video');
+    }, 3e3);
     video.addEventListener('play', function () {
         video.parentNode.classList.add('play-video');
+        clearTimeout(playTimeout);
     });
 })(document.querySelector('#start-video'));


### PR DESCRIPTION
This adds a timeout to prevent the situation when the video never plays for some reason, and so the page title is never shown. 